### PR TITLE
Allow url param to be a function

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,3 +1,3 @@
 module.exports = {
-	extends: 'danbriggs5-base',
+	extends: ['danbriggs5-base', 'plugin:prettier/recommended'],
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-ws-reconnect",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Simple reconnecting web socket for nodejs",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Allow the `url` parameter to either be a string, a function that returns a string, or a function that returns a promise that resolves with a string.
- Add `reconnectDelayMultiplier` option.

Bump to v1.1.0.